### PR TITLE
chore: Publish the latest templates (5f2d90b)

### DIFF
--- a/templates/FSS-Storage-Stack.template
+++ b/templates/FSS-Storage-Stack.template
@@ -612,9 +612,8 @@ Resources:
                 Action:
                   - s3:GetBucketNotification
                   - s3:PutBucketNotification
-                  - s3:CreateBucket
                   - s3:ListBucket
-                Resource: !Sub arn:${AWS::Partition}:s3:::${S3BucketToScan}
+                Resource: !Sub arn:${AWS::Partition}:s3:::*
 
 Outputs:
   ScanningBucket:


### PR DESCRIPTION
- Fix the issue that switching the scanning bucket to another bucket will fail the update of stacks.